### PR TITLE
IW-2730 | Provide a custom hook to let extensions provide default params

### DIFF
--- a/includes/api/ApiTemplateData.php
+++ b/includes/api/ApiTemplateData.php
@@ -149,9 +149,18 @@ class ApiTemplateData extends ApiBase {
 					// Ignore pages that already have templatedata or that don't exist.
 					continue;
 				}
-				$content = WikiPage::factory( $pageInfo['title'] )
-					->getContent( RevisionRecord::FOR_PUBLIC )
-					->getNativeData();
+
+				// Fandom change - begin - IW-2730: Provide custom hook to allow extensions to fetch default params
+				$wikiPage = WikiPage::factory( $pageInfo['title'] );
+				$hookParams = null;
+
+				if ( !Hooks::run( 'ApiTemplateDataGetRawParams', [ $wikiPage, &$hookParams ] ) ) {
+					$resp[ $pageId ][ 'params' ] = $hookParams;
+					continue;
+				}
+
+				$content = $wikiPage->getContent( RevisionRecord::FOR_PUBLIC )->getNativeData();
+				// Fandom change - end
 				$resp[ $pageId ][ 'params' ] = TemplateDataBlob::getRawParams( $content );
 			}
 		}


### PR DESCRIPTION
This allows us to return proper default parameters for portable infoboxes
without TemplateData docs; the default TemplateData parser cannot extract their
parameters.