### PR TITLE
CATS-463 | templateDataGenerator: Fix off-by-one error when inserting new tag

### DIFF
--- a/modules/ext.templateDataGenerator.target.js
+++ b/modules/ext.templateDataGenerator.target.js
@@ -243,7 +243,7 @@ mw.TemplateData.Target.prototype.replaceTemplateData = function ( newTemplateDat
 		if ( !this.isPageSubLevel ) {
 			if ( ( matches = this.originalWikitext.match( /<\/noinclude>\s*$/ ) ) ) {
 				// Move cursor inside </noinclude>
-				this.$textarea.textSelection( 'setSelection', { start: this.originalWikitext.length - matches[ 0 ].length - 1 } );
+				this.$textarea.textSelection( 'setSelection', { start: matches.index } );
 			} else {
 				// Wrap in new <noinclude>s
 				templateDataOutput = '<noinclude>\n' + templateDataOutput + '\n</noinclude>\n';


### PR DESCRIPTION
Cherry-picked https://github.com/wikimedia/mediawiki-extensions-TemplateData/commit/2b8e39a2788cffb4c7a420224c20bebfefaa49d9.

There should not be a `- 1` here. It was kept in the refactoring in
34924e0a0b2e930a60b6363941200a47bf47d0af, but it should have been removed.

Also simplify the entire expression to just `matches.index`, which is
equivalent and easier to understand. We already use `matches.index` above.

Bug: T239445
Change-Id: I9cbeaabd50fb595c0ff622b86ce3870285e5b7c8